### PR TITLE
Cleanup for demo deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "eslint": "^3.10.2",
     "eslint-config-standard": "^6.2.1",
     "eslint-plugin-promise": "^3.4.0-0",
-    "eslint-plugin-standard": "^2.0.1"
+    "eslint-plugin-standard": "^2.0.1",
+    "webpack-dev-server": "^2.4.2"
   },
   "esformatter": {
     "plugins": [
@@ -42,7 +43,9 @@
   },
   "scripts": {
     "build": "webpack",
-    "postinstall": "webpack"
+    "postinstall": "webpack",
+    "server": "webpack-dev-server --inline --progress --port 3000 --content-base .",
+    "start": "npm run server"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,13 @@
+var path = require('path');
+
 module.exports = {
 	entry: {
 		"chartIQ": "./src/app.jsx"
 	},
-	output: {
-		path: ("./dist"),
-		filename: "[name].js",
-	},
+  output: {
+    path: path.resolve(__dirname, './dist'),
+    filename: "[name].js"
+  },
 	module: {
 		loaders: [{
 			exclude: [/node_modules/, "/chartiq/"],


### PR DESCRIPTION
Fixed relative path issue that was causing webpack to fail on the deploy server
Added webpack-dev-server so users can go to http://localhost:3000 to see the demo