### PR TITLE
Mark minified files as binary.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.map binary
+*.min.js binary
+*.min.css binary
+require.js binary


### PR DESCRIPTION
Reminder that this is a quality of life setting only. Helps with namely with `git grep`.