### PR TITLE
Force simulator to use https

### DIFF
--- a/src/feeds/template.js
+++ b/src/feeds/template.js
@@ -37,7 +37,7 @@ export default class ChartService {
 			return uuid;
 		};
 
-		this.quotefeedSimulator.url = "http://simulator.chartiq.com/datafeed";
+		this.quotefeedSimulator.url = "https://simulator.chartiq.com/datafeed";
 		this.quotefeedSimulator.url += "?session=" + this.quotefeedSimulator.generateGUID(); // add on unique sessionID required by ChartIQ simulator;
 
 		// called by chart to fetch initial data


### PR DESCRIPTION
When we went to production, our charts broke. Our staging env is http (stupid), and prod is https. When a secure site tries to grab insecure quotes, the charts break. This fix will work on http and https.