### PR TITLE
update readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Using symlinks is not required. If preferred the js and css from the charting li
 You will need to install the project's dependencies and build the distribution file by running the following command from the project's root:
 
 ```
+npm install -g webpack
+npm install --save-dev webpack-cli
 npm install
 ```
 


### PR DESCRIPTION
There are `preinstall` in package.json, it runs `webpack`, but before run `npm install` users might not have `webpack` actually.
And for using webpack normally, user need webpack-cli also.

So I added 2 script before npm install, or you need to update `preinstall` in package.json. Otherwise, for those users who didn't install webpack in global, could not run `npm install` successfully.