### PR TITLE
7235 react: IE11 bug : Default text in Symbol and Comparison input box are cut off

### DIFF
--- a/css/CIQ_Seed.css
+++ b/css/CIQ_Seed.css
@@ -220,7 +220,8 @@ nav {
   border-radius: 1px;
   display: inline-block;
   border: #333 1px solid;
-  width: 100%; }
+  width: 100%;
+  height: 27px; }
 
 #symbolInput:hover, #symbolCompareInput:hover,
 #symbolInput:focus, #symbolCompareInput:focus {


### PR DESCRIPTION
Added height:27px; to nav bar input style.

Task-URL: https://devservices.chartiq.com/kanbanize/7235